### PR TITLE
Update to use plugin in newer IDE versions. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
-import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 
 fun properties(key: String) = providers.gradleProperty(key)
 fun environment(key: String) = providers.environmentVariable(key)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,17 +47,6 @@ changelog {
 
 // Configure Gradle Qodana Plugin - read more: https://github.com/JetBrains/gradle-qodana-plugin
 qodana {
-  cachePath = provider { file(".qodana").canonicalPath }
-  reportPath = provider { file("build/reports/inspections").canonicalPath }
-  saveReport = true
-  showReport = environment("QODANA_SHOW_REPORT").map { it.toBoolean() }.getOrElse(false)
-}
-
-val generateEdgeLexer = task<GenerateLexerTask>("generateEdgeLexer") {
-  source.set("src/main/java/io/stouder/adonis/edge/parsing/edge.flex")
-  targetDir.set("src/main/gen/io/stouder/adonis/edge/parsing")
-  targetClass.set("_EdgeLexer")
-  purgeOldFiles.set(true)
 }
 
 
@@ -67,7 +56,13 @@ tasks {
   }
 
   withType<JavaCompile> {
-    dependsOn(generateEdgeLexer)
+    dependsOn(generateLexer)
+  }
+
+  generateLexer {
+    sourceFile.set(file("src/main/java/io/stouder/adonis/edge/parsing/edge.flex"))
+    targetOutputDir.set(file("src/main/gen/io/stouder/adonis/edge/parsing"))
+    purgeOldFiles.set(true)
   }
 
   patchPluginXml {
@@ -123,6 +118,6 @@ tasks {
     // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
     // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
     // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-    channels = properties("pluginVersion").map { listOf(it.split('-').getOrElse(1) { "default" }.split('.').first()) }
+    channels = properties("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,19 +7,19 @@ pluginRepositoryUrl = https://github.com/Xstoudi/adonis-intellij
 pluginVersion = 0.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 223
-pluginUntilBuild = 233.*
+pluginSinceBuild = 233
+pluginUntilBuild = 242.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
-platformVersion = 2022.3.3
+platformVersion = 2024.1.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins = JavaScript
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.4
+gradleVersion = 8.7
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ pluginRepositoryUrl = https://github.com/Xstoudi/adonis-intellij
 pluginVersion = 0.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 233
-pluginUntilBuild = 242.*
+pluginSinceBuild = 241
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 # libraries
-annotations = "24.0.1"
+annotations = "24.1.0"
 
 # plugins
 changelog = "2.2.0"
-gradleIntelliJPlugin = "1.16.0"
-qodana = "0.1.13"
-grammarkit = "2021.2.1"
+gradleIntelliJPlugin = "1.17.2"
+qodana = "2023.3.1"
+grammarkit = "2022.3.2.2"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 01 19:15:41 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed May 01 19:15:41 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/stouder/adonis/action/RefreshCommandsAction.java
+++ b/src/main/java/io/stouder/adonis/action/RefreshCommandsAction.java
@@ -1,0 +1,33 @@
+package io.stouder.adonis.action;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import io.stouder.adonis.AdonisBundle;
+import io.stouder.adonis.cli.json.ace.Command;
+import io.stouder.adonis.notifier.AdonisRcUpdateNotifier;
+import io.stouder.adonis.service.AdonisAceService;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class RefreshCommandsAction extends AnAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        assert project != null;
+
+        e.getPresentation().setEnabled(false);
+        AdonisRcUpdateNotifier publisher = project.getMessageBus().syncPublisher(AdonisRcUpdateNotifier.ADONIS_RC_UPDATE_TOPIC);
+        Map<String, Optional<Command[]>> commands = AdonisAceService.getInstance(project).runAceGetCommandOnEveryRoots(
+                AdonisBundle.message("adonis.actions.refresh.commands"),
+                List.of("list", "--json"),
+                Command[].class
+        );
+        publisher.commands(commands);
+        e.getPresentation().setEnabled(true);
+    }
+}

--- a/src/main/java/io/stouder/adonis/activity/InitCommandsActivity.java
+++ b/src/main/java/io/stouder/adonis/activity/InitCommandsActivity.java
@@ -1,15 +1,18 @@
 package io.stouder.adonis.activity;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.startup.ProjectActivity;
 import io.stouder.adonis.notifier.AdonisRcUpdateNotifier;
 import io.stouder.adonis.service.AdonisAceService;
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 
-public class InitCommandsActivity implements StartupActivity {
+public class InitCommandsActivity implements ProjectActivity {
     @Override
-    public void runActivity(@NotNull Project project) {
+    public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
         AdonisRcUpdateNotifier publisher = project.getMessageBus().syncPublisher(AdonisRcUpdateNotifier.ADONIS_RC_UPDATE_TOPIC);
         AdonisAceService.getInstance(project).fetchCommands(publisher::commands);
+        return Unit.INSTANCE;
     }
 }

--- a/src/main/java/io/stouder/adonis/activity/InitRoutesActivity.java
+++ b/src/main/java/io/stouder/adonis/activity/InitRoutesActivity.java
@@ -1,15 +1,19 @@
 package io.stouder.adonis.activity;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.startup.ProjectActivity;
 import io.stouder.adonis.notifier.AdonisRouteUpdateNotifier;
 import io.stouder.adonis.service.AdonisRouteService;
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 
-public class InitRoutesActivity implements StartupActivity {
+public class InitRoutesActivity implements ProjectActivity {
+
     @Override
-    public void runActivity(@NotNull Project project) {
+    public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
         AdonisRouteUpdateNotifier publisher = project.getMessageBus().syncPublisher(AdonisRouteUpdateNotifier.ADONIS_ROUTES_UPDATE_TOPIC);
         AdonisRouteService.getInstance(project).fetchRoutes(publisher::routes);
+        return Unit.INSTANCE;
     }
 }

--- a/src/main/java/io/stouder/adonis/tool_window/AdonisToolWindow.java
+++ b/src/main/java/io/stouder/adonis/tool_window/AdonisToolWindow.java
@@ -11,12 +11,14 @@ import io.stouder.adonis.notifier.AdonisRouteUpdateNotifier;
 import io.stouder.adonis.service.AdonisAppService;
 import io.stouder.adonis.tool_window.content.MakeToolWindowContent;
 import io.stouder.adonis.tool_window.content.RoutesToolWindowContent;
+import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class AdonisToolWindow implements ToolWindowFactory {
 
     @Override
-    public boolean isApplicable(@NotNull Project project) {
+    public Object isApplicableAsync(@NotNull Project project, @NotNull Continuation<? super Boolean> $completion) {
         return AdonisAppService.getInstance(project).isAdonisProject();
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -82,6 +82,23 @@
     >
       <add-to-group group-id="io.stouder.adonis.RoutesToolbar" />
     </action>
+
+    <group
+            id="io.stouder.adonis.MakeToolbar"
+            text="Adonis"
+            description="Adonis"
+            popup="false"
+            icon="io.stouder.adonis.AdonisIcons.ADONIS"
+    />
+    <action
+            id="io.stouder.adonis.action.RefreshCommandsAction"
+            class="io.stouder.adonis.action.RefreshCommandsAction"
+            text="Refresh Commands"
+            description="Refresh Adonis commands"
+            icon="AllIcons.Actions.Refresh"
+    >
+      <add-to-group group-id="io.stouder.adonis.MakeToolbar" />
+    </action>
   </actions>
 
   <projectListeners>

--- a/src/main/resources/messages/AdonisBundle.properties
+++ b/src/main/resources/messages/AdonisBundle.properties
@@ -28,3 +28,4 @@ adonis.tool_window.make=Make
 adonis.tool_window.content.tabs.make.create=Create
 
 adonis.actions.refresh.routes=Refresh Adonis routes
+adonis.actions.refresh.commands=Refresh Adonis commands


### PR DESCRIPTION
Hi,

This is a pull request to solve ticket #25 which is about the issue from using the plugin in newer jetbrains IDE (2024.*).

I'm new to Java, it's certainly not perfect but it work for now for me so i thought it'll be good to share. I'm open to any help/informations/... about this pull request so we don't let this plugin die !

I updated many things to make it work :
- Supported IntelliJ version
- Intellij gradle plugin
- Gradle
- Updated many method which were deprecated after updating gradle.properties props : 
  - `StartupActivity.runActivity` -> `ProjectActivity.execute`
  - `ToolWindowFactory.isApplicable` -> `ToolWindowFactory.isApplicableAsync`
 